### PR TITLE
Add methods to add and remove host configurations

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over_cifs/descriptor/CifsPublisherPluginDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/descriptor/CifsPublisherPluginDescriptor.java
@@ -94,6 +94,25 @@ public class CifsPublisherPluginDescriptor extends BuildStepDescriptor<Publisher
         return null;
     }
 
+    /**
+     * Adds the given CifsHostConfiguration to the current collection of host configurations.
+     * @param configuration The CifsHostConfiguration to add.
+     */
+    public void addHostConfiguration(final CifsHostConfiguration configuration) {
+        hostConfigurations.add(configuration);
+    }
+
+    /**
+     * Removes the host configuration with the given name from the current collection of host configurations.
+     * @param name The name of the host configuration to remove.
+     */
+    public void removeHostConfiguration(final String name) {
+        CifsHostConfiguration configuration = getConfiguration(name);
+        if (configuration != null) {
+            hostConfigurations.remove(configuration);
+        }
+    }
+
     public boolean configure(final StaplerRequest request, final JSONObject formData) {
         hostConfigurations.replaceBy(request.bindJSONToList(CifsHostConfiguration.class, formData.get("instance")));
         if (isEnableOverrideDefaults())


### PR DESCRIPTION
Allows for manipulation of plugin host configurations through the script console or start-up scripts.

Nearly identical to the methods already added to the [publish-over-ssh](https://github.com/jenkinsci/publish-over-ssh-plugin) plugin, only lacking the setting of the common configuration. Didn't quite find one, so I assume we're safe to leave that out.

Pinging @ewelinawilkosz2 as this relates to her project.