### PR TITLE
Fix issue JENKINS-39344

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>publish-over</artifactId>
-            <version>0.20</version>
+            <version>0.21-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>publish-over</artifactId>
-            <version>0.21-SNAPSHOT</version>
+            <version>0.21</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsPublisher.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsPublisher.java
@@ -90,5 +90,4 @@ public class CifsPublisher extends BapPublisher<CifsTransfer> {
     public String toString() {
         return addToToString(new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)).toString();
     }
-
 }

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsPublisherPlugin.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsPublisherPlugin.java
@@ -32,6 +32,7 @@ import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.BPBuildInfo;
 import jenkins.plugins.publish_over.BPPlugin;
 import jenkins.plugins.publish_over.BPPluginDescriptor;
+import jenkins.plugins.publish_over.ParamPublish;
 import jenkins.plugins.publish_over_cifs.descriptor.CifsPublisherPluginDescriptor;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -39,6 +40,7 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,35 +50,69 @@ public class CifsPublisherPlugin extends BPPlugin<CifsPublisher, CifsClient, Obj
 
     private static final long serialVersionUID = 1L;
 
-    @DataBoundConstructor
     public CifsPublisherPlugin(final ArrayList<CifsPublisher> publishers, final boolean continueOnError, final boolean failOnError,
                                final boolean alwaysPublishFromMaster, final String masterNodeName, final CifsParamPublish paramPublish) {
         super(Messages.console_message_prefix(), publishers, continueOnError, failOnError, alwaysPublishFromMaster, masterNodeName,
                 paramPublish);
     }
 
+    @DataBoundConstructor
+    public CifsPublisherPlugin() {
+        super(Messages.console_message_prefix());
+    }
+
     public List<CifsPublisher> getPublishers() {
         return this.getDelegate().getPublishers();
+    }
+
+    @DataBoundSetter
+    public void setPublishers(final ArrayList<CifsPublisher> publishers) {
+        this.getDelegate().setPublishers(publishers);
     }
 
     public boolean isContinueOnError() {
         return this.getDelegate().isContinueOnError();
     }
 
+    @DataBoundSetter
+    public void setContinueOnError(final boolean continueOnError) {
+        this.getDelegate().setContinueOnError(continueOnError);
+    }
+
     public boolean isFailOnError() {
         return this.getDelegate().isFailOnError();
+    }
+
+    @DataBoundSetter
+    public void setFailOnError(final boolean failOnError) {
+        this.getDelegate().setFailOnError(failOnError);
     }
 
     public boolean isAlwaysPublishFromMaster() {
         return this.getDelegate().isAlwaysPublishFromMaster();
     }
 
+    @DataBoundSetter
+    public void setAlwaysPublishFromMaster(final boolean alwaysPublishFromMaster) {
+        this.getDelegate().setAlwaysPublishFromMaster(alwaysPublishFromMaster);
+    }
+
     public String getMasterNodeName() {
         return this.getDelegate().getMasterNodeName();
     }
 
+    @DataBoundSetter
+    public void setMasterNodeName(final String masterNodeName) {
+        this.getDelegate().setMasterNodeName(masterNodeName);
+    }
+
     public CifsParamPublish getParamPublish() {
         return (CifsParamPublish) this.getDelegate().getParamPublish();
+    }
+
+    @DataBoundSetter
+    public void setParamPublish(final ParamPublish paramPublish) {
+        this.getDelegate().setParamPublish(paramPublish);
     }
 
     @Override


### PR DESCRIPTION
Currently the pipeline step cifsPublisher requires the attribute paramPublish to be explicitly set to null when used in a declarative pipeline (which was also not generated by the UI). To avoid this I moved most of the attributes to DataBoundSetters.

Updated dependency to publish-over to 0.21-SNAPSHOT and moved parameters from @DataBoundConstructor to @DataBoundSetters in CifsPublisherPlugin

Requires the PR 7 from publish-over to be merged and released.