### PR TITLE
Fix default value for bufferSize when upgrade from plugin version 0.5

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsHostConfiguration.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsHostConfiguration.java
@@ -84,7 +84,9 @@ public class CifsHostConfiguration extends BPHostConfiguration<CifsClient, Objec
                                  final String remoteRootDir, final int port, final int timeout, final int bufferSize) {
         super(name, hostname, username, password, remoteRootDir, port);
         this.timeout = timeout;
-        this.bufferSize = bufferSize;
+        // when bufferSize is not entered in global config - ex. when upgrade from older version
+        // that does not know bufferSize property, then use DEFAULT_BUFFER_SIZE
+        this.bufferSize = bufferSize == 0 ? DEFAULT_BUFFER_SIZE : bufferSize;
     }
 
     protected final String getPassword() {


### PR DESCRIPTION
When I updated this plugin in Jenkins from version 0.5 to 0.6 all transfers then fail - actually they hang up during file transfer.

Global config for plugin jenkins.plugins.publish_over_cifs.CifsPublisherPlugin.xml does not contain value of buffer size thus the constructor receives bufferSize=0. So I added check to the constructor.

Workaround is to just save (no changes needed) global configuration of jenkins