### PR TITLE
fix empty "CIFS Share" drop down list for build step (JENKINS-49211)

### DIFF
--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsBuilderPlugin.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsBuilderPlugin.java
@@ -103,6 +103,9 @@ public class CifsBuilderPlugin extends Builder {
         public String getConfigPage() {
             return getViewPage(CifsPublisherPlugin.class, "config.jelly");
         }
+        public CifsPublisherPlugin.Descriptor getPublisherDescriptor() {
+            return  Jenkins.getInstance().getDescriptorByType(CifsPublisherPlugin.Descriptor.class);
+        }
     }
 
 }


### PR DESCRIPTION
This should fix the problems described in the issues [JENKINS-49211](https://issues.jenkins-ci.org/browse/JENKINS-49211) and [JENKINS-48551](https://issues.jenkins-ci.org/browse/JENKINS-48551).

The new features developed after 0.9 currently don't quite work for me, thus I didn't branched off directly from master.