### PR TITLE
Fix test connection button

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,12 @@
             <groupId>eu.agno3.jcifs</groupId>
             <artifactId>jcifs-ng</artifactId>
             <version>2.1.4</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>


### PR DESCRIPTION
Alternate to #13 this excludes the slf4j dependency and use the one provided by jenkins
I don't have an SMB share to test with but manual test of the button no longer shows the error
@blakmajk 