### PR TITLE
Stop setting `pluginFirstClassLoader`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,18 +134,6 @@
         <url>http://issues.jenkins-ci.org/</url>
     </issueManagement>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jenkins-ci.tools</groupId>
-                <artifactId>maven-hpi-plugin</artifactId>
-                <configuration>
-                    <pluginFirstClassLoader>true</pluginFirstClassLoader>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>


### PR DESCRIPTION
As far as I can tell, this is not needed, nor is it recommended. In fact, it is explicitly _not_ recommended unless the plugin has a need to override core libraries.