### PR TITLE
Bump some versions. Use 2.289.1 as minimum required Jenkins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,21 +29,21 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.13</version>
+        <version>4.19</version>
     </parent>
 
     <artifactId>publish-over-cifs</artifactId>
     <packaging>hpi</packaging>
     <name>Publish Over CIFS</name>
-    <version>0.16</version>
+    <version>0.17</version>
     <description>Send build artifacts to a windows share (CIFS/SMB/samba)</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Publish+Over+CIFS+Plugin</url>
 
     <properties>
-        <revision>0.16</revision>
+        <revision>0.17</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/publish-over-cifs-plugin</gitHubRepo>
-        <jenkins.version>2.204.6</jenkins.version>
+        <jenkins.version>2.289.1</jenkins.version>
         <java.level>8</java.level>
     </properties>
 
@@ -99,13 +99,13 @@
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>2.5.2</version>
+            <version>3.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymockclassextension</artifactId>
-            <version>2.5.2</version>
+            <version>3.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -114,8 +114,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.204.x</artifactId>
-                <version>18</version>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>1210.vcd41f6657f03</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Bump some versions, use Jenkins 2.289.1 as minimum required.