### PR TITLE
Bump Jenkins from 2.289.1 to 2.289.3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <revision>0.17</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.289.1</jenkins.version>
+        <jenkins.version>2.289.3</jenkins.version>
         <java.level>8</java.level>
     </properties>
 


### PR DESCRIPTION
This fixes Structs plugin not loading, which prevented this plugin from loading during `mvn hpi:run`



### Testing done

`mvn clean verify` works
`mvn hpi:run` works - plugin loads.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did

