### PR TITLE
Migrate legacyUrls - JENKINS-74127

### DIFF
--- a/src/main/resources/jenkins/plugins/publish_over_cifs/CifsPublisherPlugin/config.jelly
+++ b/src/main/resources/jenkins/plugins/publish_over_cifs/CifsPublisherPlugin/config.jelly
@@ -76,10 +76,10 @@
                         </f:entry>
                         <f:optionalBlock title="${m_pub.retry()}" name="retry" checked="${publisher.retry != null}"  help="${helpUrl}retry.html">
                             <f:entry title="${m_retry.retries()}" help="${helpUrl}retries.html">
-                                <f:textbox name="retries" value="${publisher.retry.retries}" default="${defaults.retry.retries}" checkUrl="${descriptor.publisherDescriptor.getCheckUrl('retries')}+'?value='+escape(this.value)"/>
+                                <f:textbox name="retries" value="${publisher.retry.retries}" default="${defaults.retry.retries}" checkUrl="${descriptor.publisherDescriptor.getCheckUrl('retries')}" checkDependsOn=""/>
                             </f:entry>
                             <f:entry title="${m_retry.retryDelay()}" help="${helpUrl}retryDelay.html">
-                                <f:textbox name="retryDelay" value="${publisher.retry.retryDelay}" default="${defaults.retry.retryDelay}" checkUrl="${descriptor.publisherDescriptor.getCheckUrl('retryDelay')}+'?value='+escape(this.value)"/>
+                                <f:textbox name="retryDelay" value="${publisher.retry.retryDelay}" default="${defaults.retry.retryDelay}" checkUrl="${descriptor.publisherDescriptor.getCheckUrl('retryDelay')}" checkDependsOn=""/>
                             </f:entry>
                         </f:optionalBlock>
                         <f:optionalBlock title="${m_pub.label()}" name="label" checked="${publisher.label != null}"  help="${helpUrl}label.html">
@@ -94,7 +94,7 @@
                             <poc:blockWrapper>
 
                                 <f:entry title="${m_trans.sourceFiles()}" help="${helpUrl}sourceFiles${promoHelpSuffix}.html">
-                                    <f:textbox name="sourceFiles" value="${transfer.sourceFiles}" checkUrl="${descriptor.publisherDescriptor.getCheckUrl('sourceFiles')}+'?value='+escape(this.value)" default="${defaults.transfer.sourceFiles}"/>
+                                    <f:textbox name="sourceFiles" value="${transfer.sourceFiles}" default="${defaults.transfer.sourceFiles}" checkUrl="${descriptor.publisherDescriptor.getCheckUrl('sourceFiles')}" checkDependsOn="" />
                                 </f:entry>
 
                                 <f:entry title="${m_trans.removePrefix()}" help="${helpUrl}removePrefix.html">

--- a/src/main/resources/jenkins/plugins/publish_over_cifs/CifsPublisherPlugin/global.groovy
+++ b/src/main/resources/jenkins/plugins/publish_over_cifs/CifsPublisherPlugin/global.groovy
@@ -16,10 +16,10 @@ f.section(description: _("hostconfig.section.description"), title: _("hostconfig
     f.repeatable(var: "instance", header: _("hostconfig.dragAndDrop"), items: descriptor.hostConfigurations) {
       poc.blockWrapper {
         f.entry(help: "${helpUrl}name.html", title: m.name()) {
-          f.textbox(name: "_.name", checkUrl: "${descriptor.getCheckUrl('name')}+'?value='+escape(this.value)", value: instance?.name)
+          f.textbox(name: "_.name", checkUrl: "${descriptor.getCheckUrl('name')}" checkDependsOn="", value: instance?.name)
         }
         f.entry(help: "${helpUrl}hostname.html", title: m.hostname()) {
-          f.textbox(name: "_.hostname", checkUrl: "${descriptor.getCheckUrl('hostname')}+'?value='+escape(this.value)", value: instance?.hostname)
+          f.textbox(name: "_.hostname", checkUrl: "${descriptor.getCheckUrl('hostname')}" checkDependsOn="", value: instance?.hostname)
         }
         f.entry(help: "${helpUrl}username.html", title: m.username()) {
           f.textbox(name: "_.username", value: instance?.username)
@@ -28,17 +28,17 @@ f.section(description: _("hostconfig.section.description"), title: _("hostconfig
           input(name: "_.password", type: "password", value: instance?.encryptedPassword, class: "setting-input")
         }
         f.entry(help: "${helpUrl}remoteRootDir.html", title: _("remotePath")) {
-          f.textbox(name: "_.remoteRootDir", checkUrl: "${descriptor.getCheckUrl('remoteRootDir')}+'?value='+escape(this.value)", value: instance?.remoteRootDir)
+          f.textbox(name: "_.remoteRootDir", checkUrl: "${descriptor.getCheckUrl('remoteRootDir')}" checkDependsOn="", value: instance?.remoteRootDir)
         }
         f.advanced() {
           f.entry(help: "${helpUrl}port.html", title: m.port()) {
-            f.textbox(default: defaultPort, name: "_.port", checkUrl: "${descriptor.getCheckUrl('port')}+'?value='+escape(this.value)", value: instance?.port)
+            f.textbox(default: defaultPort, name: "_.port", checkUrl: "${descriptor.getCheckUrl('port')}" checkDependsOn="", value: instance?.port)
           }
           f.entry(help: "${helpUrl}timeOut.html", title: m.timeout()) {
-            f.textbox(default: defaultTimeout, name: "_.timeout", checkUrl: "${descriptor.getCheckUrl('timeout')}+'?value='+escape(this.value)", value: instance?.timeout)
+            f.textbox(default: defaultTimeout, name: "_.timeout", checkUrl: "${descriptor.getCheckUrl('timeout')}" checkDependsOn="", value: instance?.timeout)
           }
           f.entry(help: "${helpUrl}bufferSize.html", title: _("hostconfig.field.bufferSize")) {
-            f.textbox(default: defaultBufferSize, name: "_.bufferSize", checkUrl: "${descriptor.getCheckUrl('bufferSize')}+'?value='+escape(this.value)", value: instance?.bufferSize)
+            f.textbox(default: defaultBufferSize, name: "_.bufferSize", checkUrl: "${descriptor.getCheckUrl('bufferSize')}" checkDependsOn="", value: instance?.bufferSize)
           }
           f.entry(help: "${helpUrl}smbVersion.html", title: _("hostconfig.field.smbVersion")) {
             select(name: "_.smbVersion", class: "setting-input") {

--- a/src/main/resources/jenkins/plugins/publish_over_cifs/CifsPublisherPlugin/global.groovy
+++ b/src/main/resources/jenkins/plugins/publish_over_cifs/CifsPublisherPlugin/global.groovy
@@ -65,7 +65,7 @@ f.section(description: _("hostconfig.section.description"), title: _("hostconfig
   if(descriptor.enableOverrideDefaults) {
     f.advanced() {
       f.entry() {
-        f.dropdownDescriptorSelector(default: descriptor.pluginDefaultsDescriptor, field: "defaults", title: descriptor.commonManageMessages.defaults()) 
+        f.dropdownDescriptorSelector(default: descriptor.pluginDefaultsDescriptor, field: "defaults", title: descriptor.commonManageMessages.defaults())
       }
     }
   }


### PR DESCRIPTION
This PR addresses JENKINS-74127 - Migrate legacyUrls. 
Following documentation at https://www.jenkins.io/doc/developer/security/csp/#legacy-javascript-checkurl-validation


### Testing done

`mvn clean verify` passes
`mvn hpi:run` performs as expected.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira


