### PR TITLE
Require Jenkins 2.479.3 and Jakarta EE 9

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.8</version>
+    <version>1.10</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,10 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>bouncycastle-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>publish-over</artifactId>
             <version>0.22</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.50</version>
+        <version>5.18</version>
         <relativePath />
     </parent>
 
@@ -45,9 +45,8 @@
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-        <jenkins.baseline>2.289</jenkins.baseline>
+        <jenkins.baseline>2.479</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
-        <java.level>8</java.level>
     </properties>
 
     <licenses>
@@ -86,10 +85,6 @@
             <version>0.22</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-        </dependency>
-        <dependency>
             <groupId>eu.agno3.jcifs</groupId>
             <artifactId>jcifs-ng</artifactId>
             <version>2.1.10</version>
@@ -101,15 +96,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <version>3.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymockclassextension</artifactId>
-            <version>3.2</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -119,7 +107,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                <version>1500.ve4d05cd32975</version>
+                <version>5015.vb_52d36583443</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsBuilderPlugin.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsBuilderPlugin.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.publish_over_cifs;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -97,6 +98,8 @@ public class CifsBuilderPlugin extends Builder {
         public boolean isApplicable(final Class<? extends AbstractProject> aClass) {
             return !BPPlugin.PROMOTION_JOB_TYPE.equals(aClass.getCanonicalName());
         }
+        @NonNull
+        @Override
         public String getDisplayName() {
             return Messages.builder_descriptor_displayName();
         }
@@ -104,7 +107,7 @@ public class CifsBuilderPlugin extends Builder {
             return getViewPage(CifsPublisherPlugin.class, "config.jelly");
         }
         public CifsPublisherPlugin.Descriptor getPublisherDescriptor() {
-            return  Jenkins.getInstance().getDescriptorByType(CifsPublisherPlugin.Descriptor.class);
+            return  Jenkins.get().getDescriptorByType(CifsPublisherPlugin.Descriptor.class);
         }
     }
 

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsCleanNodeProperties.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsCleanNodeProperties.java
@@ -24,10 +24,12 @@
 
 package jenkins.plugins.publish_over_cifs;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 public class CifsCleanNodeProperties implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 1L;
     private final String winsServer;
 

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsClient.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsClient.java
@@ -107,12 +107,9 @@ public class CifsClient extends BPDefaultClient<CifsTransfer> {
     public void transferFile(final CifsTransfer transfer, final FilePath filePath, final InputStream content) throws IOException {
         final String newFileUrl = context + filePath.getName();
         if (buildInfo.isVerbose()) buildInfo.println(Messages.console_copy(helper.hideUserInfo(newFileUrl)));
-        final OutputStream out = createFile(newFileUrl).getOutputStream();
 
-        try {
+        try (OutputStream out = createFile(newFileUrl).getOutputStream()) {
             IOUtils.copy(content, out, bufferSize);
-        } finally {
-            out.close();
         }
     }
 

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsHelper.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsHelper.java
@@ -30,8 +30,6 @@ import jenkins.plugins.publish_over.BapPublisherException;
 
 public class CifsHelper {
 
-    private static final long serialVersionUID = 1L;
-
     public SmbFile[] listFiles(final SmbFile file, final String url) {
         try {
             return file.listFiles();

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsHostConfiguration.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsHostConfiguration.java
@@ -43,17 +43,19 @@ import org.apache.commons.lang.builder.ToStringStyle;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
+import java.io.Serial;
 import java.net.MalformedURLException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 @SuppressWarnings("PMD.CyclomaticComplexity") // yeah that encode method ain't great, but we want it to be reasonably quick
 public class CifsHostConfiguration extends BPHostConfiguration<CifsClient, Object> {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     public static final String SMB_URL_PREFIX = "smb://";
@@ -264,7 +266,7 @@ public class CifsHostConfiguration extends BPHostConfiguration<CifsClient, Objec
                 return username;
             }
         }
-        return "";        
+        return "";
     }
 
     @SuppressWarnings({ "PMD.PreserveStackTrace", "PMD.JUnit4TestShouldUseTestAnnotation" }) // FFS
@@ -291,7 +293,7 @@ public class CifsHostConfiguration extends BPHostConfiguration<CifsClient, Objec
     private static String encode(final String raw) {
         if (raw == null) return null;
         final StringBuilder encoded = new StringBuilder(raw.length() * ESCAPED_BUILDER_SIZE_MULTIPLIER);
-        final CharsetEncoder encoder = Charset.forName("UTF-8").newEncoder();
+        final CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
         final CharBuffer buffer = CharBuffer.allocate(1);
         for (final char c : raw.toCharArray()) {
             if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
@@ -354,6 +356,7 @@ public class CifsHostConfiguration extends BPHostConfiguration<CifsClient, Objec
 
     // While this looks redundant, it resolves some issues with XStream Reflection causing it
     // not to persist settings after a reboot
+    @Serial
     @Override
     public Object readResolve() {
         if(bufferSize <= 0) {

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsNodeProperties.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsNodeProperties.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.publish_over_cifs;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Node;
 import hudson.slaves.NodeProperty;
@@ -35,7 +36,6 @@ import org.kohsuke.stapler.QueryParameter;
 
 public class CifsNodeProperties extends NodeProperty<Node> {
 
-    private static final long serialVersionUID = 1L;
     public static final String FORM_PREFIX = "poc-np.";
     private String winsServer;
 
@@ -49,6 +49,7 @@ public class CifsNodeProperties extends NodeProperty<Node> {
 
     @Extension
     public static class CifsWinsNodePropertyDescriptor extends NodePropertyDescriptor {
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.winsNodeProperty_descriptor_displayName();

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsParamPublish.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsParamPublish.java
@@ -31,8 +31,11 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.io.Serial;
+
 public class CifsParamPublish extends ParamPublish {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @DataBoundConstructor

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsPromotionPublisherPlugin.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsPromotionPublisherPlugin.java
@@ -37,7 +37,6 @@ import hudson.tasks.Publisher;
 import jenkins.model.Jenkins;
 import jenkins.plugins.publish_over.BPInstanceConfig;
 import jenkins.plugins.publish_over.BPPlugin;
-import jenkins.plugins.publish_over_cifs.descriptor.CifsPublisherPluginDescriptor;
 import jenkins.tasks.SimpleBuildStep;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -115,6 +114,8 @@ public class CifsPromotionPublisherPlugin extends Notifier implements SimpleBuil
         public boolean isApplicable(final Class<? extends AbstractProject> aClass) {
             return BPPlugin.PROMOTION_JOB_TYPE.equals(aClass.getCanonicalName());
         }
+        @NonNull
+        @Override
         public String getDisplayName() {
             return Messages.promotion_descriptor_displayName();
         }
@@ -123,7 +124,7 @@ public class CifsPromotionPublisherPlugin extends Notifier implements SimpleBuil
         }
 
         public CifsPublisherPlugin.Descriptor getPublisherDescriptor() {
-            return  Jenkins.getInstance().getDescriptorByType(CifsPublisherPlugin.Descriptor.class);
+            return  Jenkins.get().getDescriptorByType(CifsPublisherPlugin.Descriptor.class);
         }
     }
 

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsPublisher.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsPublisher.java
@@ -33,11 +33,13 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.io.Serial;
 import java.util.ArrayList;
 
 @SuppressWarnings("PMD.LooseCoupling") // serializable
 public class CifsPublisher extends BapPublisher<CifsTransfer> {
 
+    @Serial
     private static final long serialVersionUID = 1L;
     public static final String CTX_KEY_NODE_PROPERTIES_DEFAULT = "cifs.np.default";
     public static final String CTX_KEY_NODE_PROPERTIES_CURRENT = "cifs.np.current";

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsPublisherLabel.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsPublisherLabel.java
@@ -31,8 +31,11 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.io.Serial;
+
 public class CifsPublisherLabel extends PublisherLabel {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @DataBoundConstructor

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsPublisherPlugin.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsPublisherPlugin.java
@@ -43,12 +43,14 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.List;
 
 @SuppressWarnings("PMD.LooseCoupling") // serializable
 public class CifsPublisherPlugin extends BPPlugin<CifsPublisher, CifsClient, Object> {
 
+    @Serial
     private static final long serialVersionUID = 1L;
     private boolean publishWhenFailed = false;
 
@@ -68,7 +70,7 @@ public class CifsPublisherPlugin extends BPPlugin<CifsPublisher, CifsClient, Obj
         this.publishWhenFailed = publishWhenFailed;
     }
     public boolean getPublishWhenFailed() { return this.publishWhenFailed; }
-    
+
     public List<CifsPublisher> getPublishers() {
         return this.getDelegate().getPublishers();
     }
@@ -125,7 +127,7 @@ public class CifsPublisherPlugin extends BPPlugin<CifsPublisher, CifsClient, Obj
 
     @Override
     protected void fixup(final Run<?, ?> build, final BPBuildInfo buildInfo) {
-        final Jenkins jenkins = Jenkins.getInstance();
+        final Jenkins jenkins = Jenkins.getInstanceOrNull();
         if (jenkins != null) {
             final CifsNodeProperties defaults = jenkins.getGlobalNodeProperties().get(CifsNodeProperties.class);
             if (defaults != null) buildInfo.put(CifsPublisher.CTX_KEY_NODE_PROPERTIES_DEFAULT, map(defaults));
@@ -163,7 +165,7 @@ public class CifsPublisherPlugin extends BPPlugin<CifsPublisher, CifsClient, Obj
     }
 
     public Descriptor getDescriptor() {
-        return Jenkins.getInstance().getDescriptorByType(Descriptor.class);
+        return Jenkins.get().getDescriptorByType(Descriptor.class);
     }
 
     public CifsHostConfiguration getConfiguration(final String name) {
@@ -182,7 +184,7 @@ public class CifsPublisherPlugin extends BPPlugin<CifsPublisher, CifsClient, Obj
         }
 
     }
-    
+
     protected boolean isBuildGoodEnoughToRun(final Run<?, ?> build, final PrintStream console) {
         if (this.publishWhenFailed) {
             return true;

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsRetry.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsRetry.java
@@ -31,8 +31,11 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.io.Serial;
+
 public class CifsRetry extends Retry {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @DataBoundConstructor

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsTransfer.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsTransfer.java
@@ -32,8 +32,11 @@ import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.io.Serial;
+
 public class CifsTransfer extends BPTransfer {
 
+    @Serial
     private static final long serialVersionUID = 1L;
 
     @DataBoundConstructor

--- a/src/main/java/jenkins/plugins/publish_over_cifs/descriptor/CifsPublisherPluginDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/descriptor/CifsPublisherPluginDescriptor.java
@@ -46,8 +46,8 @@ import jenkins.plugins.publish_over_cifs.options.CifsDefaults;
 import jenkins.plugins.publish_over_cifs.options.CifsPluginDefaults;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 import org.kohsuke.stapler.verb.POST;
 
 import java.util.List;
@@ -115,7 +115,7 @@ public class CifsPublisherPluginDescriptor extends BuildStepDescriptor<Publisher
         }
     }
 
-    public boolean configure(final StaplerRequest request, final JSONObject formData) {
+    public boolean configure(final StaplerRequest2 request, final JSONObject formData) {
         hostConfigurations.replaceBy(request.bindJSONToList(CifsHostConfiguration.class, formData.get("instance")));
         if (isEnableOverrideDefaults())
             defaults = request.bindJSON(CifsDefaults.class, formData.getJSONObject("defaults"));
@@ -175,7 +175,7 @@ public class CifsPublisherPluginDescriptor extends BuildStepDescriptor<Publisher
     }
 
     @POST
-    public FormValidation doTestConnection(final StaplerRequest request, final StaplerResponse response) {
+    public FormValidation doTestConnection(final StaplerRequest2 request, final StaplerResponse2 response) {
         Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
 
         final CifsHostConfiguration hostConfig = request.bindParameters(CifsHostConfiguration.class, "");
@@ -192,7 +192,7 @@ public class CifsPublisherPluginDescriptor extends BuildStepDescriptor<Publisher
         }
     }
 
-    protected BPBuildInfo createDummyBuildInfo(final StaplerRequest request) {
+    protected BPBuildInfo createDummyBuildInfo(final StaplerRequest2 request) {
         final BPBuildInfo buildInfo = new BPBuildInfo(
                 TaskListener.NULL,
                 "",

--- a/src/main/java/jenkins/plugins/publish_over_cifs/descriptor/CifsPublisherPluginDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/descriptor/CifsPublisherPluginDescriptor.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.publish_over_cifs.descriptor;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Util;
 import hudson.model.AbstractProject;
@@ -61,7 +62,7 @@ public class CifsPublisherPluginDescriptor extends BuildStepDescriptor<Publisher
     /** null - prevent complaints from xstream */
     @SuppressFBWarnings("URF_UNREAD_FIELD")
     private Class hostConfigClass;
-    private final CopyOnWriteList<CifsHostConfiguration> hostConfigurations = new CopyOnWriteList<CifsHostConfiguration>();
+    private final CopyOnWriteList<CifsHostConfiguration> hostConfigurations = new CopyOnWriteList<>();
     private CifsDefaults defaults;
 
     public CifsPublisherPluginDescriptor() {
@@ -75,6 +76,8 @@ public class CifsPublisherPluginDescriptor extends BuildStepDescriptor<Publisher
         return defaults;
     }
 
+    @NonNull
+    @Override
     public String getDisplayName() {
         return Messages.descriptor_displayName();
     }
@@ -167,7 +170,7 @@ public class CifsPublisherPluginDescriptor extends BuildStepDescriptor<Publisher
     }
 
     public CifsPluginDefaults.CifsDefaultsDescriptor getPluginDefaultsDescriptor() {
-        return (CifsDefaults.CifsDefaultsDescriptor) Jenkins.getInstance().getDescriptor(CifsDefaults.class);
+        return (CifsDefaults.CifsDefaultsDescriptor) Jenkins.get().getDescriptor(CifsDefaults.class);
     }
 
     public jenkins.plugins.publish_over.view_defaults.manage_jenkins.Messages getCommonManageMessages() {
@@ -176,7 +179,7 @@ public class CifsPublisherPluginDescriptor extends BuildStepDescriptor<Publisher
 
     @POST
     public FormValidation doTestConnection(final StaplerRequest2 request, final StaplerResponse2 response) {
-        Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
         final CifsHostConfiguration hostConfig = request.bindParameters(CifsHostConfiguration.class, "");
         request.bindParameters(hostConfig);
@@ -196,7 +199,7 @@ public class CifsPublisherPluginDescriptor extends BuildStepDescriptor<Publisher
         final BPBuildInfo buildInfo = new BPBuildInfo(
                 TaskListener.NULL,
                 "",
-                Jenkins.getInstance().getRootPath(),
+                Jenkins.get().getRootPath(),
                 null,
                 null
         );

--- a/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsDefaults.java
@@ -33,11 +33,11 @@ import jenkins.model.Jenkins;
 public abstract class CifsDefaults implements Describable<CifsDefaults>, ExtensionPoint, CifsOptions {
 
     public static DescriptorExtensionList<CifsDefaults, CifsDefaultsDescriptor> all() {
-        return Jenkins.getInstance().getDescriptorList(CifsDefaults.class);
+        return Jenkins.get().getDescriptorList(CifsDefaults.class);
     }
 
     public CifsDefaultsDescriptor getDescriptor() {
-        return (CifsDefaultsDescriptor) Jenkins.getInstance().getDescriptor(getClass());
+        return (CifsDefaultsDescriptor) Jenkins.get().getDescriptor(getClass());
     }
 
     public abstract static class CifsDefaultsDescriptor extends Descriptor<CifsDefaults> {

--- a/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverrideDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverrideDefaults.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.publish_over_cifs.options;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.plugins.publish_over.options.InstanceConfigOptions;
 import jenkins.plugins.publish_over.options.ParamPublishOptions;
@@ -112,6 +113,7 @@ public class CifsOverrideDefaults extends CifsDefaults {
 
         private static final CifsPluginDefaults PLUGIN_DEFAULTS = new CifsPluginDefaults();
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.defaults_overrideDefaults();

--- a/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverrideInstanceConfigDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverrideInstanceConfigDefaults.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.publish_over_cifs.options;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -63,12 +64,13 @@ public class CifsOverrideInstanceConfigDefaults implements InstanceConfigOptions
         return publishWhenFailed;
     }
     public CifsOverrideInstanceConfigDefaultsDescriptor getDescriptor() {
-        return Jenkins.getInstance().getDescriptorByType(CifsOverrideInstanceConfigDefaultsDescriptor.class);
+        return Jenkins.get().getDescriptorByType(CifsOverrideInstanceConfigDefaultsDescriptor.class);
     }
 
     @Extension
     public static class CifsOverrideInstanceConfigDefaultsDescriptor extends Descriptor<CifsOverrideInstanceConfigDefaults> {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return "CifsOverrideInstanceConfigDefaultsDescriptor - not visible ...";

--- a/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverrideParamPublishDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverrideParamPublishDefaults.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.publish_over_cifs.options;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -45,12 +46,13 @@ public class CifsOverrideParamPublishDefaults implements ParamPublishOptions, De
     }
 
     public CifsOverrideParamPublishDefaultsDescriptor getDescriptor() {
-        return Jenkins.getInstance().getDescriptorByType(CifsOverrideParamPublishDefaultsDescriptor.class);
+        return Jenkins.get().getDescriptorByType(CifsOverrideParamPublishDefaultsDescriptor.class);
     }
 
     @Extension
     public static class CifsOverrideParamPublishDefaultsDescriptor extends Descriptor<CifsOverrideParamPublishDefaults> {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return "CifsOverrideParamPublishDefaultsDescriptor - not visible ...";

--- a/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverridePublisherDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverridePublisherDefaults.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.publish_over_cifs.options;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -64,12 +65,13 @@ public class CifsOverridePublisherDefaults implements PublisherOptions, Describa
     }
 
     public CifsOverridePublisherDefaultsDescriptor getDescriptor() {
-        return Jenkins.getInstance().getDescriptorByType(CifsOverridePublisherDefaultsDescriptor.class);
+        return Jenkins.get().getDescriptorByType(CifsOverridePublisherDefaultsDescriptor.class);
     }
 
     @Extension
     public static class CifsOverridePublisherDefaultsDescriptor extends Descriptor<CifsOverridePublisherDefaults> {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return "CifsOverridePublisherDefaultsDescriptor - not visible ...";

--- a/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverridePublisherLabelDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverridePublisherLabelDefaults.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.publish_over_cifs.options;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -45,12 +46,13 @@ public class CifsOverridePublisherLabelDefaults implements PublisherLabelOptions
     }
 
     public CifsOverridePublisherLabelDefaultsDescriptor getDescriptor() {
-        return Jenkins.getInstance().getDescriptorByType(CifsOverridePublisherLabelDefaultsDescriptor.class);
+        return Jenkins.get().getDescriptorByType(CifsOverridePublisherLabelDefaultsDescriptor.class);
     }
 
     @Extension
     public static class CifsOverridePublisherLabelDefaultsDescriptor extends Descriptor<CifsOverridePublisherLabelDefaults> {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return "CifsOverridePublisherLabelDefaultsDescriptor - not visible ...";

--- a/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverrideRetryDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverrideRetryDefaults.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.publish_over_cifs.options;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -53,12 +54,13 @@ public class CifsOverrideRetryDefaults implements RetryOptions, Describable<Cifs
     }
 
     public CifsOverrideRetryDefaultsDescriptor getDescriptor() {
-        return Jenkins.getInstance().getDescriptorByType(CifsOverrideRetryDefaultsDescriptor.class);
+        return Jenkins.get().getDescriptorByType(CifsOverrideRetryDefaultsDescriptor.class);
     }
 
     @Extension
     public static class CifsOverrideRetryDefaultsDescriptor extends Descriptor<CifsOverrideRetryDefaults> {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return "CifsOverrideRetryDefaultsDescriptor - not visible ...";

--- a/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverrideTransferDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverrideTransferDefaults.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.publish_over_cifs.options;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -102,12 +103,13 @@ public class CifsOverrideTransferDefaults implements TransferOptions, Describabl
     }
 
     public CifsOverrideTransferDefaultsDescriptor getDescriptor() {
-        return Jenkins.getInstance().getDescriptorByType(CifsOverrideTransferDefaultsDescriptor.class);
+        return Jenkins.get().getDescriptorByType(CifsOverrideTransferDefaultsDescriptor.class);
     }
 
     @Extension
     public static class CifsOverrideTransferDefaultsDescriptor extends Descriptor<CifsOverrideTransferDefaults> {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return "CifsOverrideTransferDefaultsDescriptor - not visible ...";

--- a/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsPluginDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsPluginDefaults.java
@@ -24,6 +24,7 @@
 
 package jenkins.plugins.publish_over_cifs.options;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import jenkins.plugins.publish_over.options.GlobalDefaults;
 import jenkins.plugins.publish_over.options.InstanceConfigOptions;
@@ -69,6 +70,7 @@ public final class CifsPluginDefaults extends CifsDefaults {
     @Extension
     public static final class CifsPluginDefaultsDescriptor extends CifsDefaultsDescriptor {
 
+        @NonNull
         @Override
         public String getDisplayName() {
             return Messages.defaults_pluginDefaults();

--- a/src/main/resources/jenkins/plugins/publish_over_cifs/CifsPublisherPlugin/global.groovy
+++ b/src/main/resources/jenkins/plugins/publish_over_cifs/CifsPublisherPlugin/global.groovy
@@ -16,10 +16,10 @@ f.section(description: _("hostconfig.section.description"), title: _("hostconfig
     f.repeatable(var: "instance", header: _("hostconfig.dragAndDrop"), items: descriptor.hostConfigurations) {
       poc.blockWrapper {
         f.entry(help: "${helpUrl}name.html", title: m.name()) {
-          f.textbox(name: "_.name", checkUrl: "${descriptor.getCheckUrl('name')}" checkDependsOn="", value: instance?.name)
+          f.textbox(name: "_.name", checkUrl: "${descriptor.getCheckUrl('name')}", checkDependsOn="", value: instance?.name)
         }
         f.entry(help: "${helpUrl}hostname.html", title: m.hostname()) {
-          f.textbox(name: "_.hostname", checkUrl: "${descriptor.getCheckUrl('hostname')}" checkDependsOn="", value: instance?.hostname)
+          f.textbox(name: "_.hostname", checkUrl: "${descriptor.getCheckUrl('hostname')}", checkDependsOn="", value: instance?.hostname)
         }
         f.entry(help: "${helpUrl}username.html", title: m.username()) {
           f.textbox(name: "_.username", value: instance?.username)
@@ -28,17 +28,17 @@ f.section(description: _("hostconfig.section.description"), title: _("hostconfig
           input(name: "_.password", type: "password", value: instance?.encryptedPassword, class: "setting-input")
         }
         f.entry(help: "${helpUrl}remoteRootDir.html", title: _("remotePath")) {
-          f.textbox(name: "_.remoteRootDir", checkUrl: "${descriptor.getCheckUrl('remoteRootDir')}" checkDependsOn="", value: instance?.remoteRootDir)
+          f.textbox(name: "_.remoteRootDir", checkUrl: "${descriptor.getCheckUrl('remoteRootDir')}", checkDependsOn="", value: instance?.remoteRootDir)
         }
         f.advanced() {
           f.entry(help: "${helpUrl}port.html", title: m.port()) {
-            f.textbox(default: defaultPort, name: "_.port", checkUrl: "${descriptor.getCheckUrl('port')}" checkDependsOn="", value: instance?.port)
+            f.textbox(default: defaultPort, name: "_.port", checkUrl: "${descriptor.getCheckUrl('port')}", checkDependsOn="", value: instance?.port)
           }
           f.entry(help: "${helpUrl}timeOut.html", title: m.timeout()) {
-            f.textbox(default: defaultTimeout, name: "_.timeout", checkUrl: "${descriptor.getCheckUrl('timeout')}" checkDependsOn="", value: instance?.timeout)
+            f.textbox(default: defaultTimeout, name: "_.timeout", checkUrl: "${descriptor.getCheckUrl('timeout')}", checkDependsOn="", value: instance?.timeout)
           }
           f.entry(help: "${helpUrl}bufferSize.html", title: _("hostconfig.field.bufferSize")) {
-            f.textbox(default: defaultBufferSize, name: "_.bufferSize", checkUrl: "${descriptor.getCheckUrl('bufferSize')}" checkDependsOn="", value: instance?.bufferSize)
+            f.textbox(default: defaultBufferSize, name: "_.bufferSize", checkUrl: "${descriptor.getCheckUrl('bufferSize')}", checkDependsOn="", value: instance?.bufferSize)
           }
           f.entry(help: "${helpUrl}smbVersion.html", title: _("hostconfig.field.smbVersion")) {
             select(name: "_.smbVersion", class: "setting-input") {

--- a/src/test/java/jenkins/plugins/publish_over_cifs/CifsClientTest.java
+++ b/src/test/java/jenkins/plugins/publish_over_cifs/CifsClientTest.java
@@ -45,7 +45,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -152,12 +151,9 @@ public class CifsClientTest {
     }
 
     @Test public void testBeginTransfersFailIfNoSourceFiles() throws Exception {
-        try {
-            new CifsClient(SingletonContext.getInstance(), buildInfo, TEST_ROOT_URL, BUFFER_SIZE).beginTransfers(new CifsTransfer("", "", "", "", false, false, false, false, false, ","));
-            fail();
-        } catch (BapPublisherException bpe) {
-            assertEquals(Messages.exception_noSourceFiles(), bpe.getMessage());
-        }
+        BapPublisherException bpe = assertThrows(BapPublisherException.class,
+                () -> new CifsClient(SingletonContext.getInstance(), buildInfo, TEST_ROOT_URL, BUFFER_SIZE).beginTransfers(new CifsTransfer("", "", "", "", false, false, false, false, false, ",")));
+        assertEquals(Messages.exception_noSourceFiles(), bpe.getMessage());
     }
 
     @Test public void testDeleteTree() throws Exception {

--- a/src/test/java/jenkins/plugins/publish_over_cifs/CifsHostConfigurationTest.java
+++ b/src/test/java/jenkins/plugins/publish_over_cifs/CifsHostConfigurationTest.java
@@ -30,7 +30,6 @@ import hudson.util.SecretHelper;
 import jcifs.CIFSContext;
 import jcifs.Configuration;
 import jcifs.ResolverType;
-import jcifs.smb.NtlmPasswordAuthentication;
 import jcifs.smb.SmbFile;
 import jenkins.plugins.publish_over.BPBuildInfo;
 import jenkins.plugins.publish_over.BapPublisherException;
@@ -38,13 +37,12 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.Serial;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -122,22 +120,14 @@ public class CifsHostConfigurationTest {
 
     @Test public void hostnameIsRequired() throws Exception {
         final CifsHostConfiguration config = new ConfigWithMockFile(CFG_NAME, "", null, null, SHARE, mockSmbFile);
-        try {
-            config.createClient(buildInfo).getContext();
-            fail();
-        } catch (final BapPublisherException bpe) {
-            assertTrue(bpe.getLocalizedMessage().contains(Messages.exception_hostnameRequired()));
-        }
+        BapPublisherException bpe = assertThrows(BapPublisherException.class, () -> config.createClient(buildInfo).getContext());
+        assertTrue(bpe.getLocalizedMessage().contains(Messages.exception_hostnameRequired()));
     }
 
     @Test public void sharenameIsRequired() throws Exception {
         final CifsHostConfiguration config = new ConfigWithMockFile(CFG_NAME, "hello", null, null, "", mockSmbFile);
-        try {
-            config.createClient(buildInfo).getContext();
-            fail();
-        } catch (final BapPublisherException bpe) {
-            assertTrue(bpe.getLocalizedMessage().contains(Messages.exception_shareRequired()));
-        }
+        BapPublisherException bpe = assertThrows(BapPublisherException.class, () -> config.createClient(buildInfo).getContext());
+        assertTrue(bpe.getLocalizedMessage().contains(Messages.exception_shareRequired()));
     }
 
     @Test public void canHazPort() throws Exception {
@@ -197,6 +187,7 @@ public class CifsHostConfigurationTest {
     }
 
     private static class ConfigWithMockFile extends CifsHostConfiguration {
+        @Serial
         private static final long serialVersionUID = 1L;
         private final transient SmbFile smbFile;
         private String url;

--- a/src/test/java/jenkins/plugins/publish_over_cifs/CifsHostConfigurationTest.java
+++ b/src/test/java/jenkins/plugins/publish_over_cifs/CifsHostConfigurationTest.java
@@ -34,23 +34,27 @@ import jcifs.smb.NtlmPasswordAuthentication;
 import jcifs.smb.SmbFile;
 import jenkins.plugins.publish_over.BPBuildInfo;
 import jenkins.plugins.publish_over.BapPublisherException;
-import org.easymock.classextension.EasyMock;
-import org.easymock.classextension.IMocksControl;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
 
-import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @SuppressWarnings({ "PMD.SignatureDeclareThrowsException", "PMD.TooManyMethods", "PMD.AvoidUsingHardCodedIP" })
+@RunWith(MockitoJUnitRunner.class)
 public class CifsHostConfigurationTest {
 
     private static final String CFG_NAME = "xxx";
@@ -62,9 +66,9 @@ public class CifsHostConfigurationTest {
     private static String origSoTimeout;
     private static String origResolveOrder;
 
-    @Rule 
+    @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule() {
-        @Override 
+        @Override
         public void before() throws Throwable {
             super.before();
             SecretHelper.setSecretKey();
@@ -90,9 +94,10 @@ public class CifsHostConfigurationTest {
         else System.setProperty(key, orig);
     }
 
-    private final transient BPBuildInfo buildInfo = new BPBuildInfo(TaskListener.NULL, "", new FilePath(new File("")), null, null);
-    private final transient IMocksControl mockControl = EasyMock.createStrictControl();
-    private final transient SmbFile mockSmbFile = mockControl.createMock(SmbFile.class);
+    private final BPBuildInfo buildInfo = new BPBuildInfo(TaskListener.NULL, "", new FilePath(new File("")), null, null);
+
+    @Mock
+    private SmbFile mockSmbFile;
 
 //    from SmbFile, this is what we are looking for:
 //    smb://[[[domain;]username[:password]@]server[:port]/[[share/[dir/]file]]][?[param=value[param2=value2[...]]]
@@ -148,12 +153,12 @@ public class CifsHostConfigurationTest {
     }
 
     private void assertUrl(final String expectedUrl, final CifsHostConfiguration hostConfig) throws Exception {
-        expect(mockSmbFile.exists()).andReturn(true);
-        expect(mockSmbFile.canRead()).andReturn(true);
-        mockControl.replay();
+        when(mockSmbFile.exists()).thenReturn(true);
+        when(mockSmbFile.canRead()).thenReturn(true);
         assertEquals(expectedUrl, hostConfig.createClient(buildInfo).getContext());
         assertEquals(expectedUrl, ((ConfigWithMockFile) hostConfig).url);
-        mockControl.verify();
+        verify(mockSmbFile).exists();
+        verify(mockSmbFile).canRead();
     }
 
     @Test public void testWinsServerIsSetFromBuildInfo() throws Exception {
@@ -164,9 +169,8 @@ public class CifsHostConfigurationTest {
         final String wins = "5.6.7.8";
         final int timeout = 45000;
         buildInfo.put(CifsPublisher.CTX_KEY_WINS_SERVER, wins);
-        expect(mockSmbFile.exists()).andReturn(true);
-        expect(mockSmbFile.canRead()).andReturn(true);
-        mockControl.replay();
+        when(mockSmbFile.exists()).thenReturn(true);
+        when(mockSmbFile.canRead()).thenReturn(true);
         final CifsHostConfiguration config = new ConfigWithMockFile(CFG_NAME, SERVER, null, null, SHARE, 99, timeout, mockSmbFile);
         Configuration c = config.createClient(buildInfo).getCifsContext().getConfig();
         assertEquals(1, c.getWinsServers().length);
@@ -174,19 +178,22 @@ public class CifsHostConfigurationTest {
         assertEquals(timeout, c.getResponseTimeout());
         assertTrue(c.getResolveOrder().contains(ResolverType.RESOLVER_WINS));
         assertTrue(c.getSoTimeout() > c.getResponseTimeout());
+        verify(mockSmbFile).exists();
+        verify(mockSmbFile).canRead();
     }
 
     @Test public void testWinsServerRemovedFromResolveOrderWhenNotSet() throws Exception {
         System.setProperty(CifsHostConfiguration.CONFIG_PROPERTY_WINS, "1.2.3.4");
         System.setProperty(CifsHostConfiguration.CONFIG_PROPERTY_RESOLVE_ORDER, "WINS");
         final int timeout = 45000;
-        expect(mockSmbFile.exists()).andReturn(true);
-        expect(mockSmbFile.canRead()).andReturn(true);
-        mockControl.replay();
+        when(mockSmbFile.exists()).thenReturn(true);
+        when(mockSmbFile.canRead()).thenReturn(true);
         final CifsHostConfiguration config = new ConfigWithMockFile(CFG_NAME, SERVER, null, null, SHARE, 99, timeout, mockSmbFile);
         Configuration c = config.createClient(buildInfo).getCifsContext().getConfig();
         assertEquals(0, c.getWinsServers().length);
         assertFalse(c.getResolveOrder().contains(ResolverType.RESOLVER_WINS));
+        verify(mockSmbFile).exists();
+        verify(mockSmbFile).canRead();
     }
 
     private static class ConfigWithMockFile extends CifsHostConfiguration {

--- a/src/test/java/jenkins/plugins/publish_over_cifs/CifsPublisherTest.java
+++ b/src/test/java/jenkins/plugins/publish_over_cifs/CifsPublisherTest.java
@@ -97,6 +97,6 @@ public class CifsPublisherTest {
     }
 
     private CifsPublisher createPublisher() {
-        return new CifsPublisher("abc", false, new ArrayList<CifsTransfer>(0), false, false, null, null);
+        return new CifsPublisher("abc", false, new ArrayList<>(0), false, false, null, null);
     }
 }

--- a/src/test/java/jenkins/plugins/publish_over_cifs/CifsPublisherTest.java
+++ b/src/test/java/jenkins/plugins/publish_over_cifs/CifsPublisherTest.java
@@ -25,41 +25,43 @@
 package jenkins.plugins.publish_over_cifs;
 
 import jenkins.plugins.publish_over.BPBuildInfo;
-import org.easymock.classextension.EasyMock;
-import org.easymock.classextension.IMocksControl;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 
 import static jenkins.plugins.publish_over_cifs.CifsPublisher.CTX_KEY_NODE_PROPERTIES_CURRENT;
 import static jenkins.plugins.publish_over_cifs.CifsPublisher.CTX_KEY_NODE_PROPERTIES_DEFAULT;
 import static jenkins.plugins.publish_over_cifs.CifsPublisher.CTX_KEY_WINS_SERVER;
-import static org.easymock.EasyMock.expect;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings({ "PMD.SignatureDeclareThrowsException", "PMD.AvoidUsingHardCodedIP" })
+@RunWith(MockitoJUnitRunner.class)
 public class CifsPublisherTest {
 
     private final BPBuildInfo buildInfo = CifsTestHelper.createEmpty();
-    private final IMocksControl mockControl = EasyMock.createNiceControl();
-    private final CifsClient mockClient = mockControl.createMock(CifsClient.class);
-    private final CifsHostConfiguration mockConfig = mockControl.createMock(CifsHostConfiguration.class);
+
+    @Mock
+    private CifsClient mockClient;
+    @Mock(strictness = Mock.Strictness.LENIENT)
+    private CifsHostConfiguration mockConfig;
 
     @Before public void setUp() {
-        expect(mockConfig.createClient(buildInfo)).andReturn(mockClient);
+        when(mockConfig.createClient(buildInfo)).thenReturn(mockClient);
     }
 
     @Test public void noWinsServerIfNoDefaultsAndNoneForNode() throws Exception {
         CifsTestHelper.setOnMaster(buildInfo);
-        mockControl.replay();
         createPublisher().perform(mockConfig, buildInfo);
         assertNull(buildInfo.get(CifsPublisher.CTX_KEY_WINS_SERVER));
     }
 
     @Test public void noWinsServerIfNoDefaultsAndOnMaster() throws Exception {
-        mockControl.replay();
         createPublisher().perform(mockConfig, buildInfo);
         assertNull(buildInfo.get(CifsPublisher.CTX_KEY_WINS_SERVER));
     }
@@ -68,7 +70,6 @@ public class CifsPublisherTest {
         final String winsServer = "1.2.3.4";
         final CifsCleanNodeProperties current = new CifsCleanNodeProperties(winsServer);
         buildInfo.put(CTX_KEY_NODE_PROPERTIES_CURRENT, current);
-        mockControl.replay();
         createPublisher().perform(mockConfig, buildInfo);
         assertEquals(winsServer, buildInfo.get(CTX_KEY_WINS_SERVER));
     }
@@ -81,7 +82,6 @@ public class CifsPublisherTest {
         buildInfo.put(CTX_KEY_NODE_PROPERTIES_CURRENT, current);
         buildInfo.put(CTX_KEY_NODE_PROPERTIES_DEFAULT, defaults);
         CifsTestHelper.setOnMaster(buildInfo);
-        mockControl.replay();
         createPublisher().perform(mockConfig, buildInfo);
         assertEquals(defaultServer, buildInfo.get(CTX_KEY_WINS_SERVER));
     }
@@ -92,7 +92,6 @@ public class CifsPublisherTest {
         final CifsCleanNodeProperties defaults = new CifsCleanNodeProperties(defaultServer);
         buildInfo.put(CTX_KEY_NODE_PROPERTIES_CURRENT, current);
         buildInfo.put(CTX_KEY_NODE_PROPERTIES_DEFAULT, defaults);
-        mockControl.replay();
         createPublisher().perform(mockConfig, buildInfo);
         assertNull(buildInfo.get(CTX_KEY_WINS_SERVER));
     }

--- a/src/test/java/jenkins/plugins/publish_over_cifs/CifsTestHelper.java
+++ b/src/test/java/jenkins/plugins/publish_over_cifs/CifsTestHelper.java
@@ -30,13 +30,14 @@ import jenkins.plugins.publish_over.BPBuildEnv;
 import jenkins.plugins.publish_over.BPBuildInfo;
 
 import java.io.File;
+import java.io.Serial;
 import java.util.Calendar;
 import java.util.TreeMap;
 
 public class CifsTestHelper {
 
     public static BPBuildEnv createEmptyBuildEnv() {
-        return new BPBuildEnv(new TreeMap<String, String>(), new FilePath(new File("")), Calendar.getInstance());
+        return new BPBuildEnv(new TreeMap<>(), new FilePath(new File("")), Calendar.getInstance());
     }
 
     public static BPBuildInfo createEmpty() {
@@ -59,6 +60,7 @@ public class CifsTestHelper {
     }
 
     public static class FakeBuildInfo extends BPBuildInfo {
+        @Serial
         private static final long serialVersionUID = 1L;
         private boolean isOnMaster;
         public FakeBuildInfo() {


### PR DESCRIPTION
## Require Jenkins 2.479.3 and Jakarta EE 9

Jenkins 2.479.3 provides Jakarta EE 9, Eclipse Jetty 12, Spring Security 6, and Java 17.

* Update plugin pom and baseline
* Remove deprecations
* Use mockito over easymock
* Use Java 17 language features
* Minor cleanup

### Testing done

`mvn clean verify`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed