### PR TITLE
Fix: duplicate `manage` in prefix of check POST URL request for fields validation

### DIFF
--- a/src/main/resources/jenkins/plugins/publish_over_cifs/CifsPublisherPlugin/global.groovy
+++ b/src/main/resources/jenkins/plugins/publish_over_cifs/CifsPublisherPlugin/global.groovy
@@ -7,40 +7,37 @@ poc = namespace("/lib/publish_over_cifs")
 
 def m = descriptor.hostConfigurationFieldNames
 def helpUrl = "/plugin/publish-over-cifs/help/global/"
-def defaultPort = jenkins.plugins.publish_over_cifs.CifsHostConfiguration.getDefaultPort()
-def defaultTimeout = jenkins.plugins.publish_over_cifs.CifsHostConfiguration.getDefaultTimeout()
-def defaultBufferSize = jenkins.plugins.publish_over_cifs.CifsHostConfiguration.getDefaultBufferSize()
 
 f.section(description: _("hostconfig.section.description"), title: _("hostconfig.section.title")) {
   f.entry(title: _("hostconfig.entry")) {
     f.repeatable(var: "instance", header: _("hostconfig.dragAndDrop"), items: descriptor.hostConfigurations) {
       poc.blockWrapper {
-        f.entry(help: "${helpUrl}name.html", title: m.name()) {
-          f.textbox(name: "_.name", checkUrl: "${descriptor.getCheckUrl('name')}", checkDependsOn="", value: instance?.name)
+        f.entry(help: "${helpUrl}name.html", title: m.name(), field: "name") {
+          f.textbox()
         }
-        f.entry(help: "${helpUrl}hostname.html", title: m.hostname()) {
-          f.textbox(name: "_.hostname", checkUrl: "${descriptor.getCheckUrl('hostname')}", checkDependsOn="", value: instance?.hostname)
+        f.entry(help: "${helpUrl}hostname.html", title: m.hostname(), field: "hostname") {
+          f.textbox()
         }
-        f.entry(help: "${helpUrl}username.html", title: m.username()) {
-          f.textbox(name: "_.username", value: instance?.username)
+        f.entry(help: "${helpUrl}username.html", title: m.username(), field: "username") {
+          f.textbox()
         }
-        f.entry(help: "${helpUrl}password.html", title: m.password()) {
+        f.entry(help: "${helpUrl}password.html", title: m.password(), field: "password") {
           input(name: "_.password", type: "password", value: instance?.encryptedPassword, class: "setting-input")
         }
-        f.entry(help: "${helpUrl}remoteRootDir.html", title: _("remotePath")) {
-          f.textbox(name: "_.remoteRootDir", checkUrl: "${descriptor.getCheckUrl('remoteRootDir')}", checkDependsOn="", value: instance?.remoteRootDir)
+        f.entry(help: "${helpUrl}remoteRootDir.html", title: _("remotePath"), field: "remoteRootDir") {
+          f.textbox()
         }
         f.advanced() {
-          f.entry(help: "${helpUrl}port.html", title: m.port()) {
-            f.textbox(default: defaultPort, name: "_.port", checkUrl: "${descriptor.getCheckUrl('port')}", checkDependsOn="", value: instance?.port)
+          f.entry(help: "${helpUrl}port.html", title: m.port(), field: "port") {
+            f.textbox()
           }
-          f.entry(help: "${helpUrl}timeOut.html", title: m.timeout()) {
-            f.textbox(default: defaultTimeout, name: "_.timeout", checkUrl: "${descriptor.getCheckUrl('timeout')}", checkDependsOn="", value: instance?.timeout)
+          f.entry(help: "${helpUrl}timeOut.html", title: m.timeout(), field: "timeout") {
+            f.textbox()
           }
-          f.entry(help: "${helpUrl}bufferSize.html", title: _("hostconfig.field.bufferSize")) {
-            f.textbox(default: defaultBufferSize, name: "_.bufferSize", checkUrl: "${descriptor.getCheckUrl('bufferSize')}", checkDependsOn="", value: instance?.bufferSize)
+          f.entry(help: "${helpUrl}bufferSize.html", title: _("hostconfig.field.bufferSize"), field: "bufferSize") {
+            f.textbox()
           }
-          f.entry(help: "${helpUrl}smbVersion.html", title: _("hostconfig.field.smbVersion")) {
+          f.entry(help: "${helpUrl}smbVersion.html", title: _("hostconfig.field.smbVersion"), field: "smbVersion") {
             select(name: "_.smbVersion", class: "setting-input") {
               jenkins.plugins.publish_over_cifs.CifsHostConfiguration.SmbVersions.values().each { ver ->
                  if(ver == instance?.smbVersion) {
@@ -52,7 +49,7 @@ f.section(description: _("hostconfig.section.description"), title: _("hostconfig
             }
           }
         }
-        f.validateButton(with: "name,hostname,username,password,remoteRootDir,port,timeout,bufferSize,poc-np.winsServer,smbVersion", method: "testConnection", progress: m.test_progress(), title: m.test_title())
+        f.validateButton(with: "name,hostname,username,password,remoteRootDir,port,timeout,bufferSize,poc-np.winsServer,smbVersion", method: "testConnection", progress: m.test_progress(), title: m.test_title(), checkMethod: "post")
         f.entry(title: "") {
           div(align: "right") {
             f.repeatableDeleteButton()


### PR DESCRIPTION
this is to fix duplicate `manage` in rendring UI for CIFS share, details ar ein issue #164 

solution provided by AI

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
