### PR TITLE
feat: Add Jenkins Configuration as Code (JCasC) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,68 @@ see Publish Over ... for [common options for Host Configurations](https://plugin
 
 # Save
 
+# Configuration as Code (JCasC)
+
+All of the system configuration described above (CIFS server host configurations, the plugin/override defaults, and the WINS server) can be managed with the [Jenkins Configuration as Code plugin](https://plugins.jenkins.io/configuration-as-code/) instead of the UI.
+
+Host configurations and defaults live under `unclassified.cifsPublisher`, and the WINS server is set through `jenkins.globalNodeProperties` using the `cifs` symbol:
+
+```yaml
+unclassified:
+  cifsPublisher:
+    hostConfigurations:
+      - name: "primary"
+        hostname: "files.example.com"
+        username: "MYDOMAIN\\jenkins"
+        password: "${CIFS_PASSWORD}"
+        remoteRootDir: "artifacts/releases"
+        port: 445
+        timeout: 45000
+        bufferSize: 8192
+        smbVersion: "SMB_V3"
+    defaults:
+      overrideDefaults:
+        overrideInstanceConfig:
+          alwaysPublishFromMaster: true
+          continueOnError: true
+          failOnError: true
+          publishWhenFailed: true
+        overrideParamPublish:
+          parameterName: "CIFS_PUBLISH"
+        overridePublisher:
+          configName: "primary"
+          useWorkspaceInPromotion: true
+          usePromotionTimestamp: true
+          verbose: true
+        overridePublisherLabel:
+          label: "release"
+        overrideRetry:
+          retries: 4
+          retryDelay: 15000
+        overrideTransfer:
+          sourceFiles: "target/*.zip"
+          excludes: "target/*-sources.zip"
+          removePrefix: "target"
+          remoteDirectory: "builds"
+          flatten: true
+          remoteDirectorySDF: true
+          cleanRemote: true
+          noDefaultExcludes: true
+          makeEmptyDirs: true
+          patternSeparator: "[, ]+"
+
+jenkins:
+  globalNodeProperties:
+    - cifs:
+        winsServer: "192.0.2.10"
+```
+
+Notes:
+
+-   Use `password` (plain text, encrypted on write) when authoring configuration, or a [secret source](https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc) reference such as `${CIFS_PASSWORD}` so the credential isn't committed in plain text. When exporting the current configuration with the "View Configuration"/export feature, the password is emitted back as an already-encrypted value and never in plain text.
+-   `defaults` accepts either `pluginDefaults` (use the global publish-over defaults unchanged) or `overrideDefaults` (override one or more of the six option groups shown above) - only set the groups you want to override, the rest fall back to the plugin defaults.
+-   If no WINS server is configured, omit the `cifs` global node property entirely.
+
 ## Send files to a windows share during a build
 
 This plugin adds a build step to enable you to send files to a windows share during a build.

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
         <jenkins.baseline>2.555</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+        <configuration-as-code.version>2121.v86fe99d4b_b_a_b_</configuration-as-code.version>
         <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
         <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
     </properties>
@@ -113,6 +114,18 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <version>${configuration-as-code.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
+            <version>${configuration-as-code.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsHostConfiguration.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsHostConfiguration.java
@@ -124,6 +124,11 @@ public class CifsHostConfiguration extends BPHostConfiguration<CifsClient, Seria
         return super.getPassword();
     }
 
+    @DataBoundSetter
+    public void setEncryptedPassword(final String encryptedPassword) {
+        setPassword(encryptedPassword);
+    }
+
     public SmbVersions getSmbVersion() { return smbVersion; }
 
     @DataBoundSetter

--- a/src/main/java/jenkins/plugins/publish_over_cifs/CifsNodeProperties.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/CifsNodeProperties.java
@@ -31,6 +31,7 @@ import hudson.slaves.NodeProperty;
 import hudson.slaves.NodePropertyDescriptor;
 import hudson.util.FormValidation;
 import jenkins.plugins.publish_over.BPValidators;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -48,6 +49,7 @@ public class CifsNodeProperties extends NodeProperty<Node> {
     public void setWinsServer(final String winsServer) { this.winsServer = winsServer; }
 
     @Extension
+    @Symbol("cifs")
     public static class CifsWinsNodePropertyDescriptor extends NodePropertyDescriptor {
         @NonNull
         @Override

--- a/src/main/java/jenkins/plugins/publish_over_cifs/descriptor/CifsPublisherPluginDescriptor.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/descriptor/CifsPublisherPluginDescriptor.java
@@ -46,6 +46,7 @@ import jenkins.plugins.publish_over_cifs.Messages;
 import jenkins.plugins.publish_over_cifs.options.CifsDefaults;
 import jenkins.plugins.publish_over_cifs.options.CifsPluginDefaults;
 import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.kohsuke.stapler.StaplerResponse2;
@@ -78,6 +79,11 @@ public class CifsPublisherPluginDescriptor extends BuildStepDescriptor<Publisher
         return defaults;
     }
 
+    @DataBoundSetter
+    public void setDefaults(final CifsDefaults defaults) {
+        this.defaults = defaults;
+    }
+
     @NonNull
     @Override
     public String getDisplayName() {
@@ -90,6 +96,11 @@ public class CifsPublisherPluginDescriptor extends BuildStepDescriptor<Publisher
 
     public List<CifsHostConfiguration> getHostConfigurations() {
         return hostConfigurations.getView();
+    }
+
+    @DataBoundSetter
+    public void setHostConfigurations(final List<CifsHostConfiguration> hostConfigurations) {
+        this.hostConfigurations.replaceBy(hostConfigurations);
     }
 
     public CifsHostConfiguration getConfiguration(final String name) {

--- a/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverrideDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsOverrideDefaults.java
@@ -33,6 +33,7 @@ import jenkins.plugins.publish_over.options.PublisherOptions;
 import jenkins.plugins.publish_over.options.RetryOptions;
 import jenkins.plugins.publish_over.options.TransferOptions;
 import jenkins.plugins.publish_over.view_defaults.manage_jenkins.Messages;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 
@@ -110,6 +111,7 @@ public class CifsOverrideDefaults extends CifsDefaults {
     }
 
     @Extension
+    @Symbol("overrideDefaults")
     @SuppressRestrictedWarnings(jenkins.plugins.publish_over.view_defaults.manage_jenkins.Messages.class)
     public static class CifsOverrideDefaultsDescriptor extends CifsDefaultsDescriptor {
 

--- a/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsPluginDefaults.java
+++ b/src/main/java/jenkins/plugins/publish_over_cifs/options/CifsPluginDefaults.java
@@ -34,6 +34,7 @@ import jenkins.plugins.publish_over.options.PublisherOptions;
 import jenkins.plugins.publish_over.options.RetryOptions;
 import jenkins.plugins.publish_over.options.TransferOptions;
 import jenkins.plugins.publish_over.view_defaults.manage_jenkins.Messages;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 
@@ -69,6 +70,7 @@ public final class CifsPluginDefaults extends CifsDefaults {
     }
 
     @Extension
+    @Symbol("pluginDefaults")
     @SuppressRestrictedWarnings(jenkins.plugins.publish_over.view_defaults.manage_jenkins.Messages.class)
     public static final class CifsPluginDefaultsDescriptor extends CifsDefaultsDescriptor {
 

--- a/src/test/java/jenkins/plugins/publish_over_cifs/ConfigurationAsCodeTest.java
+++ b/src/test/java/jenkins/plugins/publish_over_cifs/ConfigurationAsCodeTest.java
@@ -1,0 +1,119 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2010-2011 by Anthony Robinson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package jenkins.plugins.publish_over_cifs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.util.Secret;
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.misc.junit.jupiter.WithJenkinsConfiguredWithCode;
+import jenkins.plugins.publish_over_cifs.options.CifsOverrideDefaults;
+import jenkins.plugins.publish_over_cifs.options.CifsPluginDefaults;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+@WithJenkinsConfiguredWithCode
+class ConfigurationAsCodeTest {
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code.yml")
+    void shouldImportAllSystemConfiguration(JenkinsConfiguredWithCodeRule rule) {
+        assertSystemConfiguration(rule);
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code.yml")
+    void shouldExportAndReapplyAllSystemConfiguration(JenkinsConfiguredWithCodeRule rule) throws Exception {
+        String exported = rule.exportToString(true);
+
+        assertTrue(exported.contains("cifsPublisher:"));
+        assertTrue(exported.contains("overrideDefaults:"));
+        assertTrue(exported.contains("winsServer: \"192.0.2.10\""));
+        assertFalse(exported.contains("cifs-secret"));
+
+        CifsPublisherPlugin.Descriptor descriptor =
+                rule.jenkins.getDescriptorByType(CifsPublisherPlugin.Descriptor.class);
+        descriptor.setHostConfigurations(List.of());
+        descriptor.setDefaults(new CifsPluginDefaults());
+        rule.jenkins.getGlobalNodeProperties().clear();
+
+        Path exportedFile = Files.createTempFile(rule.jenkins.getRootDir().toPath(), "cifs-casc-", ".yml");
+        Files.writeString(exportedFile, exported);
+        ConfigurationAsCode.get().configure(exportedFile.toString());
+
+        assertSystemConfiguration(rule);
+    }
+
+    private static void assertSystemConfiguration(JenkinsConfiguredWithCodeRule rule) {
+        CifsPublisherPlugin.Descriptor descriptor =
+                rule.jenkins.getDescriptorByType(CifsPublisherPlugin.Descriptor.class);
+
+        assertEquals(1, descriptor.getHostConfigurations().size());
+        CifsHostConfiguration host = descriptor.getHostConfigurations().get(0);
+        assertEquals("primary", host.getName());
+        assertEquals("files.example.test", host.getHostname());
+        assertEquals("EXAMPLE\\jenkins", host.getUsername());
+        assertEquals("cifs-secret", Secret.toString(Secret.decrypt(host.getEncryptedPassword())));
+        assertEquals("artifacts/releases", host.getRemoteRootDir());
+        assertEquals(445, host.getPort());
+        assertEquals(45000, host.getTimeout());
+        assertEquals(8192, host.getBufferSize());
+        assertEquals(CifsHostConfiguration.SmbVersions.SMB_V3, host.getSmbVersion());
+
+        CifsOverrideDefaults defaults = assertInstanceOf(CifsOverrideDefaults.class, descriptor.getDefaults());
+        assertTrue(defaults.getOverrideInstanceConfig().isAlwaysPublishFromMaster());
+        assertTrue(defaults.getOverrideInstanceConfig().isContinueOnError());
+        assertTrue(defaults.getOverrideInstanceConfig().isFailOnError());
+        assertTrue(defaults.getOverrideInstanceConfig().isPublishWhenFailed());
+        assertEquals("CIFS_PUBLISH", defaults.getOverrideParamPublish().getParameterName());
+        assertEquals("primary", defaults.getOverridePublisher().getConfigName());
+        assertTrue(defaults.getOverridePublisher().isUseWorkspaceInPromotion());
+        assertTrue(defaults.getOverridePublisher().isUsePromotionTimestamp());
+        assertTrue(defaults.getOverridePublisher().isVerbose());
+        assertEquals("release", defaults.getOverridePublisherLabel().getLabel());
+        assertEquals(4, defaults.getOverrideRetry().getRetries());
+        assertEquals(15000, defaults.getOverrideRetry().getRetryDelay());
+        assertEquals("target/*.zip", defaults.getOverrideTransfer().getSourceFiles());
+        assertEquals("target/*-sources.zip", defaults.getOverrideTransfer().getExcludes());
+        assertEquals("target", defaults.getOverrideTransfer().getRemovePrefix());
+        assertEquals("builds", defaults.getOverrideTransfer().getRemoteDirectory());
+        assertTrue(defaults.getOverrideTransfer().isFlatten());
+        assertTrue(defaults.getOverrideTransfer().isRemoteDirectorySDF());
+        assertTrue(defaults.getOverrideTransfer().isCleanRemote());
+        assertTrue(defaults.getOverrideTransfer().isNoDefaultExcludes());
+        assertTrue(defaults.getOverrideTransfer().isMakeEmptyDirs());
+        assertEquals("[, ]+", defaults.getOverrideTransfer().getPatternSeparator());
+
+        CifsNodeProperties nodeProperties = rule.jenkins.getGlobalNodeProperties().get(CifsNodeProperties.class);
+        assertEquals("192.0.2.10", nodeProperties.getWinsServer());
+    }
+}

--- a/src/test/resources/jenkins/plugins/publish_over_cifs/configuration-as-code.yml
+++ b/src/test/resources/jenkins/plugins/publish_over_cifs/configuration-as-code.yml
@@ -1,0 +1,47 @@
+unclassified:
+  cifsPublisher:
+    hostConfigurations:
+      - name: "primary"
+        hostname: "files.example.test"
+        username: "EXAMPLE\\jenkins"
+        password: "cifs-secret"
+        remoteRootDir: "artifacts/releases"
+        port: 445
+        timeout: 45000
+        bufferSize: 8192
+        smbVersion: "SMB_V3"
+    defaults:
+      overrideDefaults:
+        overrideInstanceConfig:
+          alwaysPublishFromMaster: true
+          continueOnError: true
+          failOnError: true
+          publishWhenFailed: true
+        overrideParamPublish:
+          parameterName: "CIFS_PUBLISH"
+        overridePublisher:
+          configName: "primary"
+          useWorkspaceInPromotion: true
+          usePromotionTimestamp: true
+          verbose: true
+        overridePublisherLabel:
+          label: "release"
+        overrideRetry:
+          retries: 4
+          retryDelay: 15000
+        overrideTransfer:
+          sourceFiles: "target/*.zip"
+          excludes: "target/*-sources.zip"
+          removePrefix: "target"
+          remoteDirectory: "builds"
+          flatten: true
+          remoteDirectorySDF: true
+          cleanRemote: true
+          noDefaultExcludes: true
+          makeEmptyDirs: true
+          patternSeparator: "[, ]+"
+
+jenkins:
+  globalNodeProperties:
+    - cifs:
+        winsServer: "192.0.2.10"


### PR DESCRIPTION
Expose descriptor-level setters (host configurations, defaults) and @Symbol annotations (overrideDefaults, pluginDefaults, cifs WINS node property) so JCasC can configure and export the full CIFS publisher system configuration, including round-tripping the password as an encrypted value only. Adds test-scope JCasC dependencies and an import/export round-trip test, and documents the new YAML schema in the README.

Address #97 

### Testing done


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed


